### PR TITLE
Postpone the initialization

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh.rb
+++ b/lib/smart_proxy_remote_execution_ssh.rb
@@ -11,8 +11,6 @@ require 'smart_proxy_remote_execution_ssh/api'
 module Proxy::RemoteExecution
   module Ssh
     class << self
-      attr_reader :dispatcher
-
       def initialize
         unless private_key_file
           raise "settings for `ssh_identity_key` not set"
@@ -32,6 +30,10 @@ module Proxy::RemoteExecution
                                                                     :logger => Proxy::Dynflow.instance.world.logger)
       end
 
+      def dispatcher
+        @dispatcher || initialize
+      end
+
       def private_key_file
         File.expand_path(Ssh::Plugin.settings.ssh_identity_key_file)
       end
@@ -42,3 +44,5 @@ module Proxy::RemoteExecution
     end
   end
 end
+
+Proxy::Dynflow.after_initialize { Proxy::RemoteExecution::Ssh.initialize }

--- a/lib/smart_proxy_remote_execution_ssh/command_action.rb
+++ b/lib/smart_proxy_remote_execution_ssh/command_action.rb
@@ -31,6 +31,10 @@ module Proxy::RemoteExecution::Ssh
       else
         raise "Unexpected event #{event.inspect}"
       end
+    rescue => e
+      action_logger.error e
+      output[:result] << Connector::DebugData.new("#{e.class}: #{e.message}").to_hash
+      output[:exit_status] = "PROXY_ERROR"
     end
 
     def finalize

--- a/lib/smart_proxy_remote_execution_ssh/connector.rb
+++ b/lib/smart_proxy_remote_execution_ssh/connector.rb
@@ -17,6 +17,12 @@ module Proxy::RemoteExecution::Ssh
       def data_type
         raise NotImplemented
       end
+
+      def to_hash
+        { :output_type => data_type,
+          :output      => data,
+          :timestamp   => timestamp.to_f }
+      end
     end
 
     class StdoutData < Data

--- a/lib/smart_proxy_remote_execution_ssh/dispatcher.rb
+++ b/lib/smart_proxy_remote_execution_ssh/dispatcher.rb
@@ -38,11 +38,7 @@ module Proxy::RemoteExecution::Ssh
       end
 
       def buffer_to_hash
-        buffer.map do |buffer_data|
-          { :output_type => buffer_data.data_type,
-            :output      => buffer_data.data,
-            :timestamp   => buffer_data.timestamp.to_f }
-        end
+        buffer.map(&:to_hash)
       end
     end
 

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -7,9 +7,5 @@ module Proxy::RemoteExecution::Ssh
     default_settings :ssh_identity_key_file => '~/.ssh/id_rsa_foreman_proxy',
                      :ssh_user => 'root'
     plugin :ssh, Proxy::RemoteExecution::Ssh::VERSION
-
-    after_activation do
-      Proxy::RemoteExecution::Ssh.initialize
-    end
   end
 end

--- a/smart_proxy_remote_execution_ssh.gemspec
+++ b/smart_proxy_remote_execution_ssh.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rack-test', '~> 0')
   gem.add_development_dependency('rubocop', '0.32.1')
 
-  gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.0.1')
+  gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.0.3')
 
   gem.add_runtime_dependency('net-ssh')
   gem.add_runtime_dependency('net-scp')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,19 +12,25 @@ require 'smart_proxy_dynflow'
 require 'smart_proxy_dynflow/testing'
 require 'smart_proxy_remote_execution_ssh'
 
-WORLD = Proxy::Dynflow::Testing.create_world
 DATA_DIR = File.expand_path('../data', __FILE__)
-
 FAKE_PRIVATE_KEY_FILE = File.join(DATA_DIR, 'fake_id_rsa')
 FAKE_PUBLIC_KEY_FILE = "#{FAKE_PRIVATE_KEY_FILE}.pub"
-Proxy::RemoteExecution::Ssh::Plugin.settings.ssh_identity_key_file = FAKE_PRIVATE_KEY_FILE
+
+def prepare_fake_keys
+  Proxy::RemoteExecution::Ssh::Plugin.settings.ssh_identity_key_file = FAKE_PRIVATE_KEY_FILE
+  FileUtils.mkdir_p(DATA_DIR) unless File.exist?(DATA_DIR)
+  File.write(FAKE_PRIVATE_KEY_FILE, '===private-key===')
+  File.write(FAKE_PUBLIC_KEY_FILE, '===public-key===')
+end
+
+prepare_fake_keys
+
+WORLD = Proxy::Dynflow::Testing.create_world
 
 class MiniTest::Test
   def setup
     Support::DummyConnector.reset
-    FileUtils.mkdir_p(DATA_DIR) unless File.exist?(DATA_DIR)
-    File.write(FAKE_PRIVATE_KEY_FILE, '===private-key===')
-    File.write(FAKE_PUBLIC_KEY_FILE, '===public-key===')
+    prepare_fake_keys
   end
 
   def teardown


### PR DESCRIPTION
We can't initialize the plugin sooner than the smart proxy forks in 
production, because otherwise we loose the file descriptors we need to open at 
the initialization phase.

Therefore, we use hooking mechanism that smart_proxy_dynflow provides