### PR TITLE
Fix README in gemspec

### DIFF
--- a/smart_proxy_remote_execution_ssh.gemspec
+++ b/smart_proxy_remote_execution_ssh.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
     Ssh remote execution provider for Foreman Smart-Proxy
   EOS
 
-  gem.files            = Dir['{bundler.d,lib,settings.d}/**/*', 'LICENSE', 'README*']
-  gem.extra_rdoc_files = ['README*', 'LICENSE']
+  gem.files            = Dir['{bundler.d,lib,settings.d}/**/*', 'LICENSE', 'README.md']
+  gem.extra_rdoc_files = ['README.md', 'LICENSE']
   gem.test_files       = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths    = ["lib"]
   gem.license = 'GPLv3'


### PR DESCRIPTION
Gem's unhappy

```
$ gem build smart_proxy_remote_execution_ssh.gemspec
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["README*"] are not files
```