### PR TITLE
Fixes #11553 - introduce session actors to avoid blocking on opening connections

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh.rb
+++ b/lib/smart_proxy_remote_execution_ssh.rb
@@ -3,6 +3,8 @@ require 'smart_proxy_dynflow'
 require 'smart_proxy_remote_execution_ssh/version'
 require 'smart_proxy_remote_execution_ssh/plugin'
 
+require 'smart_proxy_remote_execution_ssh/connector'
+require 'smart_proxy_remote_execution_ssh/command_update'
 require 'smart_proxy_remote_execution_ssh/dispatcher'
 require 'smart_proxy_remote_execution_ssh/command_action'
 

--- a/lib/smart_proxy_remote_execution_ssh/command_action.rb
+++ b/lib/smart_proxy_remote_execution_ssh/command_action.rb
@@ -16,7 +16,7 @@ module Proxy::RemoteExecution::Ssh
       case event
       when nil
         init_run
-      when Dispatcher::CommandUpdate
+      when CommandUpdate
         update = event
         output[:result].concat(update.buffer_to_hash)
         if update.exit_status

--- a/lib/smart_proxy_remote_execution_ssh/command_update.rb
+++ b/lib/smart_proxy_remote_execution_ssh/command_update.rb
@@ -1,0 +1,73 @@
+module Proxy::RemoteExecution::Ssh
+  # update sent back to the suspended action
+  class CommandUpdate
+    attr_reader :buffer, :exit_status
+
+    def initialize(buffer)
+      @buffer = buffer
+      extract_exit_status
+    end
+
+    def extract_exit_status
+      @buffer.delete_if do |data|
+        if data.is_a? StatusData
+          @exit_status = data.data
+          true
+        end
+      end
+    end
+
+    def buffer_to_hash
+      buffer.map(&:to_hash)
+    end
+
+    def self.encode_exception(description, exception, fatal = true)
+      ret = [DebugData.new("#{description}\n#{exception.class} #{exception.message}")]
+      ret << StatusData.new('EXCEPTION') if fatal
+      return ret
+    end
+
+    class Data
+      attr_reader :data, :timestamp
+
+      def initialize(data, timestamp = Time.now)
+        @data = data
+        @timestamp = timestamp
+      end
+
+      def data_type
+        raise NotImplemented
+      end
+
+      def to_hash
+        { :output_type => data_type,
+          :output => data,
+          :timestamp => timestamp.to_f }
+      end
+    end
+
+    class StdoutData < Data
+      def data_type
+        :stdout
+      end
+    end
+
+    class StderrData < Data
+      def data_type
+        :stderr
+      end
+    end
+
+    class DebugData < Data
+      def data_type
+        :debug
+      end
+    end
+
+    class StatusData < Data
+      def data_type
+        :status
+      end
+    end
+  end
+end

--- a/lib/smart_proxy_remote_execution_ssh/dispatcher.rb
+++ b/lib/smart_proxy_remote_execution_ssh/dispatcher.rb
@@ -1,4 +1,4 @@
-require 'smart_proxy_remote_execution_ssh/connector'
+require 'smart_proxy_remote_execution_ssh/session'
 
 module Proxy::RemoteExecution::Ssh
   # Service that handles running external commands for Actions::Command
@@ -28,204 +28,65 @@ module Proxy::RemoteExecution::Ssh
       end
     end
 
-    # update sent back to the suspended action
-    class CommandUpdate
-      attr_reader :buffer, :exit_status
-
-      def initialize(buffer, exit_status)
-        @buffer      = buffer
-        @exit_status = exit_status
-      end
-
-      def buffer_to_hash
-        buffer.map(&:to_hash)
-      end
-    end
-
     def initialize(options = {})
       @clock                   = options[:clock] || Dynflow::Clock.spawn('proxy-dispatcher-clock')
       @logger                  = options[:logger] || Logger.new($stderr)
-      @connector_class         = options[:connector_class] || Connector
-      @local_working_dir       = options[:local_working_dir] || '/tmp/foreman-proxy-ssh/server'
-      @remote_working_dir      = options[:remote_working_dir] || '/tmp/foreman-proxy-ssh/client'
-      @refresh_interval        = options[:refresh_interval] || 1
-      @client_private_key_file = Proxy::RemoteExecution::Ssh.private_key_file
 
-      @connectors        = {}
-      @command_buffer    = Hash.new { |h, k| h[k] = [] }
-      @refresh_planned = false
+      @session_args = { :logger => @logger,
+                        :clock => @clock,
+                        :connector_class => options[:connector_class] || Connector,
+                        :local_working_dir => options[:local_working_dir] || '/tmp/foreman-proxy-ssh/server',
+                        :remote_working_dir => options[:remote_working_dir] || '/tmp/foreman-proxy-ssh/client',
+                        :client_private_key_file => Proxy::RemoteExecution::Ssh.private_key_file,
+                        :refresh_interval => options[:refresh_interval] || 1 }
+
+      @sessions = {}
     end
 
     def initialize_command(command)
       @logger.debug("initalizing command [#{command}]")
-      connector = self.connector_for_command(command)
-      remote_script = cp_script_to_remote(connector, command)
-      if command.effective_user && command.effective_user != command.ssh_user
-        su_prefix = "su - #{command.effective_user} -c "
-      end
-      output_path = File.join(File.dirname(remote_script), 'output')
-
-      connector.async_run("#{su_prefix}#{remote_script} | /usr/bin/tee #{output_path}") do |data|
-        command_buffer(command) << data
-      end
-    rescue => e
-      @logger.error("error while initalizing command #{e.class} #{e.message}:\n #{e.backtrace.join("\n")}")
-      command_buffer(command).concat([Connector::DebugData.new("Exception: #{e.class} #{e.message}"),
-                                      Connector::StatusData.new('INIT_ERROR')])
-    ensure
-      plan_next_refresh
-    end
-
-    def refresh
-      finished_commands = []
-      refresh_connectors
-
-      @command_buffer.each do |command, buffer|
-        unless buffer.empty?
-          status = refresh_command_buffer(command, buffer)
-          if status
-            finished_commands << command
-          end
-        end
-      end
-
-      finished_commands.each { |command| finish_command(command) }
-      close_inactive_connectors
-    ensure
-      @refresh_planned = false
-      plan_next_refresh
-    end
-
-    def refresh_command_buffer(command, buffer)
-      status = nil
-      @logger.debug("command #{command} got new output: #{buffer.inspect}")
-      buffer.delete_if do |data|
-        if data.is_a? Connector::StatusData
-          status = data.data
-          true
-        end
-      end
-      command.suspended_action << CommandUpdate.new(buffer, status)
-      clear_command(command)
-      if status
-        @logger.debug("command [#{command}] finished with status #{status}")
-        return status
-      end
+      open_session(command)
+    rescue => exception
+      handle_command_exception(command, exception)
     end
 
     def kill(command)
       @logger.debug("killing command [#{command}]")
-      connector_for_command(command).run("pkill -f #{remote_command_file(command, 'script')}")
-    end
-
-    protected
-
-    def connector_for_command(command, only_if_exists = false)
-      if connector = @connectors[[command.host, command.ssh_user]]
-        return connector
-      end
-      return nil if only_if_exists
-      @connectors[[command.host, command.ssh_user]] = open_connector(command)
-    end
-
-    def local_command_dir(command)
-      File.join(@local_working_dir, command.id)
-    end
-
-    def local_command_file(command, filename)
-      File.join(local_command_dir(command), filename)
-    end
-
-    def remote_command_dir(command)
-      File.join(@remote_working_dir, command.id)
-    end
-
-    def remote_command_file(command, filename)
-      File.join(remote_command_dir(command), filename)
-    end
-
-    def ensure_local_directory(path)
-      if File.exist?(path)
-        raise "#{path} expected to be a directory" unless File.directory?(path)
-      else
-        FileUtils.mkdir_p(path)
-      end
-      return path
-    end
-
-    def cp_script_to_remote(connector, command)
-      local_script_file = write_command_file_locally(command, 'script', command.script)
-      File.chmod(0777, local_script_file)
-      remote_script_file = remote_command_file(command, 'script')
-      connector.upload_file(local_script_file, remote_script_file)
-      return remote_script_file
-    end
-
-    def write_command_file_locally(command, filename, content)
-      path = local_command_file(command, filename)
-      ensure_local_directory(File.dirname(path))
-      File.write(path, content)
-      return path
-    end
-
-    def open_connector(command)
-      options = { :logger => @logger }
-      options[:known_hosts_file] = prepare_known_hosts(command)
-      options[:client_private_key_file] = @client_private_key_file
-      @connector_class.new(command.host, command.ssh_user, options)
-    end
-
-    def prepare_known_hosts(command)
-      path = local_command_file(command, 'known_hosts')
-      if command.host_public_key
-        write_command_file_locally(command, 'known_hosts', "#{command.host} #{command.host_public_key}")
-      end
-      return path
-    end
-
-    def close_inactive_connectors
-      @connectors.delete_if do |_, connector|
-        if connector.inactive?
-          connector.close
-          true
-        end
-      end
-    end
-
-    def refresh_connectors
-      @logger.debug("refreshing #{@connectors.size} connectors")
-
-      @connectors.values.each do |connector|
-        begin
-          connector.refresh
-        rescue => e
-          @command_buffer.each do |command, buffer|
-            if connector_for_command(command, false)
-              buffer << Connector::DebugData.new("Exception: #{e.class} #{e.message}")
-            end
-          end
-        end
-      end
-    end
-
-    def command_buffer(command)
-      @command_buffer[command]
-    end
-
-    def clear_command(command)
-      @command_buffer[command] = []
+      session = @sessions[command.id]
+      session.tell(:kill) if session
+    rescue => exception
+      handle_command_exception(command, exception, false)
     end
 
     def finish_command(command)
-      @command_buffer.delete(command)
+      close_session(command)
+    rescue => exception
+      handle_command_exception(command, exception)
     end
 
-    def plan_next_refresh
-      if @connectors.any? && !@refresh_planned
-        @logger.debug("planning to refresh")
-        @clock.ping(reference, Time.now + @refresh_interval, :refresh)
-        @refresh_planned = true
-      end
+    private
+
+    def handle_command_exception(command, exception, fatal = true)
+      @logger.error("error while dispatching command #{command} to session:"\
+                    "#{exception.class} #{exception.message}:\n #{exception.backtrace.join("\n")}")
+      command_data = CommandUpdate.encode_exception("Failed to dispatch the command", exception, fatal)
+      command.suspended_action << CommandUpdate.new(command_data)
+      close_session(command) if fatal
+    end
+
+    def open_session(command)
+      raise "Session already opened for command #{command}" if @sessions[command.id]
+      options = { :name => "proxy-ssh-session-#{command.host}-#{command.ssh_user}-#{command.id}",
+                  :args => [@session_args.merge(:command => command)],
+                  :supervise => true }
+      @sessions[command.id] = Proxy::RemoteExecution::Ssh::Session.spawn(options)
+    end
+
+    def close_session(command)
+      session = @sessions.delete(command.id)
+      return unless session
+      @logger.debug("closing session for command [#{command}], #{@sessions.size} session(s) left ")
+      session.tell([:start_termination, Concurrent.future])
     end
   end
 end

--- a/lib/smart_proxy_remote_execution_ssh/session.rb
+++ b/lib/smart_proxy_remote_execution_ssh/session.rb
@@ -1,0 +1,169 @@
+require 'smart_proxy_remote_execution_ssh/session'
+
+module Proxy::RemoteExecution::Ssh
+  # Service that handles running external commands for Actions::Command
+  # Dynflow action. It runs just one (actor) thread for all the commands
+  # running in the system and updates the Dynflow actions periodically.
+  class Session < ::Dynflow::Actor
+    def initialize(options = {})
+      @clock = options[:clock] || Dynflow::Clock.spawn('proxy-dispatcher-clock')
+      @logger = options[:logger] || Logger.new($stderr)
+      @connector_class = options[:connector_class] || Connector
+      @local_working_dir = options[:local_working_dir] || '/tmp/foreman-proxy-ssh/server'
+      @remote_working_dir = options[:remote_working_dir] || '/tmp/foreman-proxy-ssh/client'
+      @refresh_interval = options[:refresh_interval] || 1
+      @client_private_key_file = Proxy::RemoteExecution::Ssh.private_key_file
+      @command = options[:command]
+
+      @command_buffer = []
+      @refresh_planned = false
+
+      reference.tell(:initialize_command)
+    end
+
+    def initialize_command
+      @logger.debug("initalizing command [#{@command}]")
+      open_connector
+      remote_script = cp_script_to_remote
+      if @command.effective_user && @command.effective_user != @command.ssh_user
+        su_prefix = "su - #{@command.effective_user} -c "
+      end
+      output_path = File.join(File.dirname(remote_script), 'output')
+
+      @connector.async_run("#{su_prefix}#{remote_script} | /usr/bin/tee #{output_path}") do |data|
+        @command_buffer << data
+      end
+    rescue => e
+      @logger.error("error while initalizing command #{e.class} #{e.message}:\n #{e.backtrace.join("\n")}")
+      @command_buffer.concat(CommandUpdate.encode_exception("Error initializing command #{@command}", e))
+      refresh
+    ensure
+      plan_next_refresh
+    end
+
+    def refresh
+      @connector.refresh if @connector
+
+      unless @command_buffer.empty?
+        status = refresh_command_buffer
+        if status
+          finish_command
+        end
+      end
+    rescue => e
+      @command_buffer.concat(CommandUpdate.encode_exception("Failed to refresh the connector", e, false))
+    ensure
+      @refresh_planned = false
+      plan_next_refresh
+    end
+
+    def refresh_command_buffer
+      @logger.debug("command #{@command} got new output: #{@command_buffer.inspect}")
+      command_update = CommandUpdate.new(@command_buffer)
+      @command.suspended_action << command_update
+      @command_buffer = []
+      if command_update.exit_status
+        @logger.debug("command [#{@command}] finished with status #{command_update.exit_status}")
+        return command_update.exit_status
+      end
+    end
+
+    def kill
+      @logger.debug("killing command [#{@command}]")
+      if @connector
+        @connector.run("pkill -f #{remote_command_file('script')}")
+      else
+        @logger.debug("connection closed")
+      end
+    rescue => e
+      @command_buffer.concat(CommandUpdate.encode_exception("Failed to kill the command", e, false))
+      plan_next_refresh
+    end
+
+    def finish_command
+      close
+      dispatcher.tell([:finish_command, @command])
+    end
+
+    def dispatcher
+      self.parent
+    end
+
+    def start_termination(*args)
+      super
+      close
+      finish_termination
+    end
+
+    private
+
+    def open_connector
+      raise 'Connector already opened' if @connector
+      options = { :logger => @logger }
+      options[:known_hosts_file] = prepare_known_hosts
+      options[:client_private_key_file] = @client_private_key_file
+      @connector = @connector_class.new(@command.host, @command.ssh_user, options)
+    end
+
+    def local_command_dir
+      File.join(@local_working_dir, @command.id)
+    end
+
+    def local_command_file(filename)
+      File.join(local_command_dir, filename)
+    end
+
+    def remote_command_dir
+      File.join(@remote_working_dir, @command.id)
+    end
+
+    def remote_command_file(filename)
+      File.join(remote_command_dir, filename)
+    end
+
+    def ensure_local_directory(path)
+      if File.exist?(path)
+        raise "#{path} expected to be a directory" unless File.directory?(path)
+      else
+        FileUtils.mkdir_p(path)
+      end
+      return path
+    end
+
+    def cp_script_to_remote
+      local_script_file = write_command_file_locally('script', @command.script)
+      File.chmod(0777, local_script_file)
+      remote_script_file = remote_command_file('script')
+      @connector.upload_file(local_script_file, remote_script_file)
+      return remote_script_file
+    end
+
+    def write_command_file_locally(filename, content)
+      path = local_command_file(filename)
+      ensure_local_directory(File.dirname(path))
+      File.write(path, content)
+      return path
+    end
+
+    def prepare_known_hosts
+      path = local_command_file('known_hosts')
+      if @command.host_public_key
+        write_command_file_locally('known_hosts', "#{@command.host} #{@command.host_public_key}")
+      end
+      return path
+    end
+
+    def close
+      @connector.close if @connector
+      @connector = nil
+    end
+
+    def plan_next_refresh
+      if @connector && !@refresh_planned
+        @logger.debug("planning to refresh")
+        @clock.ping(reference, Time.now + @refresh_interval, :refresh)
+        @refresh_planned = true
+      end
+    end
+  end
+end

--- a/test/command_action_test.rb
+++ b/test/command_action_test.rb
@@ -35,7 +35,7 @@ module Proxy::RemoteExecution::Ssh
 
     it 'saves the command update to the output' do
       action = create_and_plan_action CommandAction, command_input
-      command_update = Dispatcher::CommandUpdate.new([Connector::StdoutData.new('Hello world')], nil)
+      command_update = CommandUpdate.new([CommandUpdate::StdoutData.new('Hello world')])
       dispatcher.expects(:tell)
       action = run_action action
 
@@ -47,7 +47,7 @@ module Proxy::RemoteExecution::Ssh
       result_item[:output].must_equal "Hello world"
       result_item[:timestamp].must_be_kind_of Numeric
 
-      command_update = Dispatcher::CommandUpdate.new([Connector::StderrData.new('Finished')], 1)
+      command_update = CommandUpdate.new([CommandUpdate::StderrData.new('Finished'), CommandUpdate::StatusData.new(1)])
       action = run_action action, command_update
       action.output['result'].size.must_equal 2
       result_item  = action.output['result'].last

--- a/test/support/dummy_connector.rb
+++ b/test/support/dummy_connector.rb
@@ -21,6 +21,9 @@ module Support
 
     def run(command)
       log_call(:run, command)
+      if command.include?('pkill')
+        self.class.mocked_async_run_data << Proxy::RemoteExecution::Ssh::CommandUpdate::StatusData.new('SIGINT')
+      end
       return *self.class.mocked_run_data
     end
 
@@ -35,12 +38,9 @@ module Support
       end
     end
 
-    def inactive?
-      self.class.inactive?
-    end
-
     def close
       @block = nil
+      self.class.close
     end
 
     private
@@ -53,11 +53,8 @@ module Support
       attr_reader :log, :mocked_async_run_data, :finished
       attr_accessor :last
 
-      def inactive?
-        if mocked_async_run_data.empty?
-          @finished.success(true)
-          return true
-        end
+      def close
+        @finished.success(true)
       end
 
       def mocked_run_data

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,8 @@ require 'smart_proxy_for_testing'
 require 'support/dummy_connector'
 
 require 'smart_proxy_dynflow'
+
+# DYNFLOW_TESTING_LOG_LEVEL = 0 # for debugging
 require 'smart_proxy_dynflow/testing'
 require 'smart_proxy_remote_execution_ssh'
 


### PR DESCRIPTION
The commands now work more independently, not having wait while other 
connections are getting opened.