### PR TITLE
fixes #11979 - pin net-ssh

### DIFF
--- a/smart_proxy_remote_execution_ssh.gemspec
+++ b/smart_proxy_remote_execution_ssh.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.0.3')
 
-  gem.add_runtime_dependency('net-ssh')
+  gem.add_runtime_dependency('net-ssh', '<= 2.10.0')
   gem.add_runtime_dependency('net-scp')
 end


### PR DESCRIPTION
2.10.0 seems to be fine, 2.10.1.rc and newer requires ruby 2.0.
