### PR TITLE
fixes #11955, #12422 - use /var/tmp and a unique path on clients

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/dispatcher.rb
+++ b/lib/smart_proxy_remote_execution_ssh/dispatcher.rb
@@ -35,8 +35,8 @@ module Proxy::RemoteExecution::Ssh
       @session_args = { :logger => @logger,
                         :clock => @clock,
                         :connector_class => options[:connector_class] || Connector,
-                        :local_working_dir => options[:local_working_dir] || '/tmp/foreman-proxy-ssh/server',
-                        :remote_working_dir => options[:remote_working_dir] || '/tmp/foreman-proxy-ssh/client',
+                        :local_working_dir => options[:local_working_dir] || ::Proxy::RemoteExecution::Ssh::Plugin.settings.local_working_dir,
+                        :remote_working_dir => options[:remote_working_dir] || ::Proxy::RemoteExecution::Ssh::Plugin.settings.remote_working_dir,
                         :client_private_key_file => Proxy::RemoteExecution::Ssh.private_key_file,
                         :refresh_interval => options[:refresh_interval] || 1 }
 

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -5,7 +5,10 @@ module Proxy::RemoteExecution::Ssh
 
     settings_file "remote_execution_ssh.yml"
     default_settings :ssh_identity_key_file => '~/.ssh/id_rsa_foreman_proxy',
-                     :ssh_user => 'root'
+                     :ssh_user              => 'root',
+                     :remote_working_dir    => '/var/tmp',
+                     :local_working_dir     => '/var/tmp'
+
     plugin :ssh, Proxy::RemoteExecution::Ssh::VERSION
   end
 end

--- a/lib/smart_proxy_remote_execution_ssh/session.rb
+++ b/lib/smart_proxy_remote_execution_ssh/session.rb
@@ -9,8 +9,8 @@ module Proxy::RemoteExecution::Ssh
       @clock = options[:clock] || Dynflow::Clock.spawn('proxy-dispatcher-clock')
       @logger = options[:logger] || Logger.new($stderr)
       @connector_class = options[:connector_class] || Connector
-      @local_working_dir = options[:local_working_dir] || '/tmp/foreman-proxy-ssh/server'
-      @remote_working_dir = options[:remote_working_dir] || '/tmp/foreman-proxy-ssh/client'
+      @local_working_dir = options[:local_working_dir] || ::Proxy::RemoteExecution::Ssh::Plugin.settings.local_working_dir
+      @remote_working_dir = options[:remote_working_dir] || ::Proxy::RemoteExecution::Ssh::Plugin.settings.remote_working_dir
       @refresh_interval = options[:refresh_interval] || 1
       @client_private_key_file = Proxy::RemoteExecution::Ssh.private_key_file
       @command = options[:command]
@@ -113,7 +113,7 @@ module Proxy::RemoteExecution::Ssh
     end
 
     def local_command_dir
-      File.join(@local_working_dir, @command.id)
+      File.join(@local_working_dir, 'foreman-proxy', "foreman-ssh-cmd-#{@command.id}")
     end
 
     def local_command_file(filename)
@@ -121,7 +121,7 @@ module Proxy::RemoteExecution::Ssh
     end
 
     def remote_command_dir
-      File.join(@remote_working_dir, @command.id)
+      File.join(@remote_working_dir, "foreman-ssh-cmd-#{@command.id}")
     end
 
     def remote_command_file(filename)

--- a/settings.d/remote_execution_ssh.yml.example
+++ b/settings.d/remote_execution_ssh.yml.example
@@ -1,3 +1,5 @@
 ---
 :enabled: true
 :ssh_identity_key_file: '~/.ssh/id_rsa_foreman_proxy'
+:local_working_dir: '/var/tmp'
+:remote_working_dir: '/var/tmp'

--- a/test/dispatcher_test.rb
+++ b/test/dispatcher_test.rb
@@ -20,8 +20,8 @@ module Proxy::RemoteExecution::Ssh
                        :clock => WORLD.clock,
                        :logger => WORLD.logger,
                        :connector_class => Support::DummyConnector,
-                       :local_working_dir => "#{DATA_DIR}/server",
-                       :remote_working_dir => "#{DATA_DIR}/client")
+                       :local_working_dir => "#{DATA_DIR}",
+                       :remote_working_dir => "#{DATA_DIR}")
     end
 
     let :mocked_async_run_data do
@@ -49,11 +49,11 @@ module Proxy::RemoteExecution::Ssh
       expected_connector_calls =
           [["root@test.example.com",
             :upload_file,
-            "#{DATA_DIR}/server/123/script",
-            "#{DATA_DIR}/client/123/script"],
+            "#{DATA_DIR}/foreman-proxy/foreman-ssh-cmd-123/script",
+            "#{DATA_DIR}/foreman-ssh-cmd-123/script"],
            ["root@test.example.com",
             :async_run,
-            "#{DATA_DIR}/client/123/script"]]
+            "#{DATA_DIR}/foreman-ssh-cmd-123/script"]]
 
       Support::DummyConnector.log.must_equal expected_connector_calls
     end
@@ -72,11 +72,11 @@ module Proxy::RemoteExecution::Ssh
         expected_connector_calls =
             [["root@test.example.com",
               :upload_file,
-              "#{DATA_DIR}/server/123/script",
-              "#{DATA_DIR}/client/123/script"],
+              "#{DATA_DIR}/foreman-proxy/foreman-ssh-cmd-123/script",
+              "#{DATA_DIR}/foreman-ssh-cmd-123/script"],
              ["root@test.example.com",
               :async_run,
-              "su - guest -c #{DATA_DIR}/client/123/script"]]
+              "su - guest -c #{DATA_DIR}/foreman-ssh-cmd-123/script"]]
 
         Support::DummyConnector.log.must_equal expected_connector_calls
       end
@@ -121,7 +121,7 @@ module Proxy::RemoteExecution::Ssh
         Support::DummyConnector.reset
         Support::DummyConnector.mocked_async_run_data << CommandUpdate::StdoutData.new('Hello world')
         dispatcher.ask([:initialize_command, command]).wait
-        expected_connector_call = ["root@test.example.com", :run, "pkill -f #{DATA_DIR}/client/123/script"]
+        expected_connector_call = ["root@test.example.com", :run, "pkill -f #{DATA_DIR}/foreman-ssh-cmd-123/script"]
 
         dispatcher.ask([:kill, command]).wait
         Support::DummyConnector.wait


### PR DESCRIPTION
Reason for /var/tmp was they actually did want them persisted on reboots, and also many places mount /tmp as noexec.

https://groups.google.com/forum/#!msg/foreman-users/yXFMiB324G0/6bTIMSaVBwAJ