### PR TITLE
Fixes #12456 - handle the encoding in general, not just in stdout/stderr

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/command_update.rb
+++ b/lib/smart_proxy_remote_execution_ssh/command_update.rb
@@ -32,6 +32,7 @@ module Proxy::RemoteExecution::Ssh
 
       def initialize(data, timestamp = Time.now)
         @data = data
+        @data = @data.force_encoding('UTF-8') if @data.is_a? String
         @timestamp = timestamp
       end
 

--- a/lib/smart_proxy_remote_execution_ssh/connector.rb
+++ b/lib/smart_proxy_remote_execution_ssh/connector.rb
@@ -22,9 +22,9 @@ module Proxy::RemoteExecution::Ssh
     def async_run(command)
       started = false
       session.open_channel do |channel|
-        channel.on_data { |ch, data| yield CommandUpdate::StdoutData.new(handle_encoding(data)) }
+        channel.on_data { |ch, data| yield CommandUpdate::StdoutData.new(data) }
 
-        channel.on_extended_data { |ch, type, data| yield CommandUpdate::StderrData.new(handle_encoding(data)) }
+        channel.on_extended_data { |ch, type, data| yield CommandUpdate::StderrData.new(data) }
 
         # standard exit of the command
         channel.on_request("exit-status") { |ch, data| yield CommandUpdate::StatusData.new(data.read_long) }
@@ -119,14 +119,6 @@ module Proxy::RemoteExecution::Ssh
     end
 
     private
-
-    def handle_encoding(data)
-      if data.is_a? String
-        data.force_encoding('UTF-8')
-      else
-        data
-      end
-    end
 
     def session
       @session ||= begin

--- a/test/command_update_test.rb
+++ b/test/command_update_test.rb
@@ -2,16 +2,12 @@
 require 'test_helper'
 
 module Proxy::RemoteExecution::Ssh
-  class ConnectorTest < MiniTest::Spec
-    let :connector do
-      Support::DummyConnector.new('test.example.com', 'root')
-    end
-
+  class CommandUpdateTest < MiniTest::Spec
     it 'is able to handle encoding' do
       # Simulate output from the connector
       out = '├─2045 /usr/sbin/httpd -DFOREGROUND'.force_encoding('ASCII-8BIT')
-      new_out = connector.send(:handle_encoding, out)
-      new_out.must_equal '├─2045 /usr/sbin/httpd -DFOREGROUND'
+      update = CommandUpdate::StdoutData.new(out)
+      update.data.must_equal '├─2045 /usr/sbin/httpd -DFOREGROUND'
     end
   end
 end


### PR DESCRIPTION
We can run into similar issues with exceptions as well. Handling the encoding
on more high level.