### PR TITLE
Fixes #12902 - Handle net-ssh dependency differently

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,12 @@ source 'https://rubygems.org'
 
 gemspec
 
+if RUBY_VERSION.start_with? '1.9.'
+    gem 'net-ssh', '< 3'
+else
+    gem 'net-ssh'
+end
+
 group :development do
   gem 'smart_proxy', :git => "https://github.com/theforeman/smart-proxy", :branch => "develop"
   gem 'smart_proxy_dynflow', :git => "https://github.com/theforeman/smart_proxy_dynflow"

--- a/lib/smart_proxy_remote_execution_ssh/version.rb
+++ b/lib/smart_proxy_remote_execution_ssh/version.rb
@@ -1,7 +1,7 @@
 module Proxy
   module RemoteExecution
     module Ssh
-      VERSION = '0.0.9'
+      VERSION = '0.0.10'
     end
   end
 end

--- a/smart_proxy_remote_execution_ssh.gemspec
+++ b/smart_proxy_remote_execution_ssh.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.0.3')
 
-  gem.add_runtime_dependency('net-ssh', '<= 2.10.0')
+  gem.add_runtime_dependency('net-ssh')
   gem.add_runtime_dependency('net-scp')
 end


### PR DESCRIPTION
Some OS platforms will move on to packaging net-ssh 3.x only