### PR TITLE
Fixes #12786 - Load sinatra earlier to ensure it's available

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh.rb
+++ b/lib/smart_proxy_remote_execution_ssh.rb
@@ -1,14 +1,4 @@
-require 'smart_proxy_dynflow'
-
-require 'smart_proxy_remote_execution_ssh/version'
 require 'smart_proxy_remote_execution_ssh/plugin'
-
-require 'smart_proxy_remote_execution_ssh/connector'
-require 'smart_proxy_remote_execution_ssh/command_update'
-require 'smart_proxy_remote_execution_ssh/dispatcher'
-require 'smart_proxy_remote_execution_ssh/command_action'
-
-require 'smart_proxy_remote_execution_ssh/api'
 
 module Proxy::RemoteExecution
   module Ssh

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -10,5 +10,14 @@ module Proxy::RemoteExecution::Ssh
                      :local_working_dir     => '/var/tmp'
 
     plugin :ssh, Proxy::RemoteExecution::Ssh::VERSION
+    after_activation do
+      require 'smart_proxy_dynflow'
+      require 'smart_proxy_remote_execution_ssh/version'
+      require 'smart_proxy_remote_execution_ssh/connector'
+      require 'smart_proxy_remote_execution_ssh/command_update'
+      require 'smart_proxy_remote_execution_ssh/dispatcher'
+      require 'smart_proxy_remote_execution_ssh/command_action'
+      require 'smart_proxy_remote_execution_ssh/api'
+    end
   end
 end


### PR DESCRIPTION
Before this patch, Sinatra could be referenced before it's loaded.
This patch simply allows it to load when the plugin is loaded.