### PR TITLE
fixes #15385 - match foreman's version requirement on net-ssh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,6 @@ source 'https://rubygems.org'
 
 gemspec :name => 'smart_proxy_remote_execution_ssh_core'
 
-if RUBY_VERSION.start_with? '1.9.'
-    gem 'net-ssh', '< 3'
-else
-    gem 'net-ssh'
-end
-
 group :development do
   gem 'smart_proxy', :git => "https://github.com/theforeman/smart-proxy", :branch => "develop"
   gem 'smart_proxy_dynflow', :git => "https://github.com/theforeman/smart_proxy_dynflow"

--- a/smart_proxy_remote_execution_ssh_core.gemspec
+++ b/smart_proxy_remote_execution_ssh_core.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('smart_proxy_dynflow_core', '>= 0.0.7')
 
-  gem.add_runtime_dependency('net-ssh', '<= 2.9.4')
+  gem.add_runtime_dependency('net-ssh')
   gem.add_runtime_dependency('net-scp')
 end


### PR DESCRIPTION
As we're running in the same SCL, we need to be compat with the version
they're shipping.