### PR TITLE
fixes #16321 - Invocation of script on target host

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh_core/session.rb
+++ b/lib/smart_proxy_remote_execution_ssh_core/session.rb
@@ -32,7 +32,7 @@ module Proxy
           # pipe the output to tee while capturing the exit code
           script = <<-SCRIPT
             exec 4>&1
-            exit_code=`((#{su_prefix}#{remote_script}; echo $?>&3 ) | /usr/bin/tee #{output_path} ) 3>&1 >&4`
+            exit_code=`((#{su_prefix} $SHELL <#{remote_script}; echo $?>&3 ) | /usr/bin/tee #{output_path} ) 3>&1 >&4`
             exec 4>&-
             exit $exit_code
           SCRIPT


### PR DESCRIPTION
I changed the acls for the script file to not be be writeable by others,
not sure if you can actually use to manipulate the job but better safe
than sorry

also I changed the invocation of the script on the receiver because
if you have noexec set to /tmp and /var/tmp bind mounted to tmp
like redhat recommends then execution of the script does not work.