### PR TITLE
fixes #16322 - Insecure permissions on script file

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh_core/session.rb
+++ b/lib/smart_proxy_remote_execution_ssh_core/session.rb
@@ -162,7 +162,7 @@ module Proxy
 
         def cp_script_to_remote
           local_script_file = write_command_file_locally('script', sanitize_script(@command.script))
-          File.chmod(0777, local_script_file)
+          File.chmod(0444, local_script_file)
           remote_script_file = remote_command_file('script')
           @connector.upload_file(local_script_file, remote_script_file)
           return remote_script_file


### PR DESCRIPTION
I changed the acls for the script file to not be be writeable by others,
not sure if you can actually use to manipulate the job but better safe
than sorry

Needs http://projects.theforeman.org/issues/16322 // #29 or different permissions (0555)