### PR TITLE
Do not use mocha methods outside of tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,8 +29,6 @@ def prepare_fake_keys
   File.write(FAKE_PUBLIC_KEY_FILE, '===public-key===')
 end
 
-prepare_fake_keys
-
 class MiniTest::Test
   def setup
     prepare_fake_keys


### PR DESCRIPTION
This fixes the error in CI:

Mocha methods cannot be used outside the context of a test