### PR TITLE
ssh/session: Stop Webrick from using a hijacked socket

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/cockpit.rb
+++ b/lib/smart_proxy_remote_execution_ssh/cockpit.rb
@@ -103,8 +103,8 @@ module Proxy::RemoteExecution
 
       def hijack!
         @socket = nil
-        if @env['WEBRICK_SOCKET']
-          @socket = @env['WEBRICK_SOCKET']
+        if @env['ext.hijack!']
+	  @socket = @env['ext.hijack!'].call
         elsif @env['rack.hijack?']
           begin
             @env['rack.hijack'].call

--- a/lib/smart_proxy_remote_execution_ssh/webrick_ext.rb
+++ b/lib/smart_proxy_remote_execution_ssh/webrick_ext.rb
@@ -3,7 +3,13 @@ module SmartProxyRemoteExecutionSsh
     # An extension to ::WEBrick::HTTPRequest to expost the socket object for highjacking for cockpit
     module HTTPRequestExt
       def meta_vars
-        super.merge('WEBRICK_SOCKET' => @socket)
+        super.merge('ext.hijack!' => -> {
+                      # This stops Webrick from sending its own reply.
+                      @request_line = nil;
+                      # This stops Webrick from trying to read the next request on the socket.
+                      @keep_alive = false;
+                      return @socket;
+                    })
       end
     end
   end


### PR DESCRIPTION
This avoids spurious error messages when Webrick tries to use a closed
socket.  The error itself seems to be harmless, but it makes it into
the log file as a backtrace, which is misleading.