### PR TITLE
Unpin dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,26 +8,12 @@ group :development do
 end
 
 group :test do
-  if RUBY_VERSION < '2.1'
-    gem 'public_suffix', '< 3'
-  else
-    gem 'public_suffix'
-  end
-  
-  if RUBY_VERSION < '2.2'
-    gem 'rack-test', '< 0.8'
-  else
-    gem 'rack-test'
-  end
+  gem 'public_suffix'
+  gem 'rack-test'
 end
 
-if RUBY_VERSION < '2.2'
-  gem 'sinatra', '< 2'
-  gem 'rack', '>= 1.1', '< 2.0.0'
-else
-  gem 'sinatra'
-  gem 'rack', '>= 1.1'
-end
+gem 'sinatra'
+gem 'rack', '>= 1.1'
 
 # load local gemfile
 local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local.rb')

--- a/smart_proxy_remote_execution_ssh.gemspec
+++ b/smart_proxy_remote_execution_ssh.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |gem|
   gem.require_paths    = ["lib"]
   gem.license = 'GPL-3.0'
 
-  gem.add_development_dependency "bundler", "~> 1.7"
-  gem.add_development_dependency "rake", "~> 10.0"
+  gem.add_development_dependency "bundler"
+  gem.add_development_dependency "rake"
   gem.add_development_dependency('minitest')
   gem.add_development_dependency('mocha', '~> 1')
   gem.add_development_dependency('webmock', '~> 1')


### PR DESCRIPTION
Now that the Smart proxy can use a modern Ruby version and drop < 2.4, it's no longer needed to pin these dependencies. For Rake 10 there are known security issues.