### PR TITLE
Unpin dependencies

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 4
-# Configuration parameters: Include.
-# Include: **/*.gemfile, **/Gemfile, **/gems.rb
-Bundler/DuplicatedGem:
-  Exclude:
-    - 'Gemfile'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: TreatCommentsAsGroupSeparators, Include.
@@ -28,12 +21,6 @@ Gemspec/OrderedDependencies:
 Layout/BlockAlignment:
   Exclude:
     - 'lib/smart_proxy_remote_execution_ssh/webrick_ext.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/EmptyLineAfterMagicComment:
-  Exclude:
-    - 'smart_proxy_remote_execution_ssh.gemspec'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -68,20 +55,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
   Exclude:
     - 'lib/smart_proxy_remote_execution_ssh/api.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: final_newline, final_blank_line
-Layout/TrailingEmptyLines:
-  Exclude:
-    - 'Gemfile'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowInHeredoc.
-Layout/TrailingWhitespace:
-  Exclude:
-    - 'Gemfile'
 
 # Offense count: 1
 Lint/LiteralAsCondition:
@@ -127,7 +100,6 @@ Metrics/BlockLength:
 # ForbiddenDelimiters: (?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))
 Naming/HeredocDelimiterNaming:
   Exclude:
-    - 'smart_proxy_remote_execution_ssh.gemspec'
     - 'test/api_test.rb'
 
 # Offense count: 1
@@ -144,18 +116,11 @@ Naming/MethodParameterName:
   Exclude:
     - 'lib/smart_proxy_remote_execution_ssh/cockpit.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/Encoding:
-  Exclude:
-    - 'smart_proxy_remote_execution_ssh.gemspec'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 Style/ExpandPathArguments:
   Exclude:
     - 'lib/smart_proxy_remote_execution_ssh/plugin.rb'
-    - 'smart_proxy_remote_execution_ssh.gemspec'
     - 'test/test_helper.rb'
 
 # Offense count: 1

--- a/Gemfile
+++ b/Gemfile
@@ -8,28 +8,13 @@ group :development do
 end
 
 group :test do
-  if RUBY_VERSION < '2.1'
-    gem 'public_suffix', '< 3'
-  else
-    gem 'public_suffix'
-  end
-  
-  if RUBY_VERSION < '2.2'
-    gem 'rack-test', '< 0.8'
-  else
-    gem 'rack-test'
-  end
+  gem 'public_suffix'
+  gem 'rack-test'
 end
 
-if RUBY_VERSION < '2.2'
-  gem 'sinatra', '< 2'
-  gem 'rack', '>= 1.1', '< 2.0.0'
-else
-  gem 'sinatra'
-  gem 'rack', '>= 1.1'
-end
+gem 'sinatra'
+gem 'rack', '>= 1.1'
 
 # load local gemfile
 local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local.rb')
 self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)
-

--- a/smart_proxy_remote_execution_ssh.gemspec
+++ b/smart_proxy_remote_execution_ssh.gemspec
@@ -1,5 +1,4 @@
-# -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'smart_proxy_remote_execution_ssh/version'
 
@@ -10,9 +9,9 @@ Gem::Specification.new do |gem|
   gem.email         = ['inecas@redhat.com']
   gem.homepage      = "https://github.com/theforeman/smart_proxy_remote_execution_ssh"
   gem.summary       = 'Ssh remote execution provider for Foreman Smart-Proxy'
-  gem.description   = <<-EOS
+  gem.description   = <<-DESCRIPTION
     Ssh remote execution provider for Foreman Smart-Proxy
-  EOS
+  DESCRIPTION
 
   gem.files            = Dir['lib/smart_proxy_remote_execution_ssh.rb', 'LICENSE', 'README.md',
                              '{lib/smart_proxy_remote_execution_ssh,settings.d}/**/*',
@@ -22,13 +21,13 @@ Gem::Specification.new do |gem|
   gem.require_paths    = ["lib"]
   gem.license = 'GPL-3.0'
 
-  gem.add_development_dependency "bundler", ">= 1.7"
-  gem.add_development_dependency "rake", "~> 10.0"
+  gem.add_development_dependency "bundler"
+  gem.add_development_dependency "rake"
   gem.add_development_dependency('minitest')
   gem.add_development_dependency('mocha', '~> 1')
   gem.add_development_dependency('webmock', '~> 1')
   gem.add_development_dependency('rack-test', '~> 0')
-  gem.add_development_dependency('rubocop', '0.32.1')
+  gem.add_development_dependency('rubocop', '~> 0.82.0')
 
   gem.add_runtime_dependency('smart_proxy_dynflow', '>= 0.1.0', '< 0.3.0')
   gem.add_runtime_dependency('net-ssh')


### PR DESCRIPTION
Now that the Smart proxy can use a modern Ruby version and drop < 2.4,
it's no longer needed to pin these dependencies. For Rake 10 there are
known security issues.

Reopening #47 - thanks @ekohl !