### PR TITLE
Fixes #32774 - use directly smart_proxy_dynflow

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh.rb
+++ b/lib/smart_proxy_remote_execution_ssh.rb
@@ -1,8 +1,7 @@
-require 'foreman_tasks_core'
-require 'smart_proxy_remote_execution_ssh/version'
 require 'smart_proxy_dynflow'
-require 'smart_proxy_remote_execution_ssh/webrick_ext'
+require 'smart_proxy_remote_execution_ssh/version'
 require 'smart_proxy_remote_execution_ssh/plugin'
+require 'smart_proxy_remote_execution_ssh/webrick_ext'
 
 module Proxy::RemoteExecution
   module Ssh
@@ -53,8 +52,5 @@ module Proxy::RemoteExecution
         Plugin.settings.ssh_log_level = Plugin.settings.ssh_log_level.to_sym
       end
     end
-
-    require 'smart_proxy_dynflow_core/task_launcher_registry'
-    SmartProxyDynflowCore::TaskLauncherRegistry.register('ssh', ForemanTasksCore::TaskLauncher::Batch)
   end
 end

--- a/lib/smart_proxy_remote_execution_ssh/actions/run_script.rb
+++ b/lib/smart_proxy_remote_execution_ssh/actions/run_script.rb
@@ -1,8 +1,9 @@
-require 'foreman_tasks_core/shareable_action'
+require 'smart_proxy_dynflow/action/shareable'
+require 'smart_proxy_dynflow/action/runner'
 
 module Proxy::RemoteExecution::Ssh
   module Actions
-    class RunScript < ForemanTasksCore::Runner::Action
+    class RunScript < Proxy::Dynflow::Action::Runner
       def initiate_runner
         additional_options = {
           :step_id => run_step_id,

--- a/lib/smart_proxy_remote_execution_ssh/dispatcher.rb
+++ b/lib/smart_proxy_remote_execution_ssh/dispatcher.rb
@@ -1,7 +1,7 @@
-require 'foreman_tasks_core/runner/dispatcher'
+require 'smart_proxy_dynflow/runner/dispatcher'
 
 module Proxy::RemoteExecution::Ssh
-  class Dispatcher < ::ForemanTasksCore::Runner::Dispatcher
+  class Dispatcher < ::Proxy::Dynflow::Runner::Dispatcher
     def refresh_interval
       @refresh_interval ||= Plugin.settings[:runner_refresh_interval] ||
                             Plugin.runner_class::DEFAULT_REFRESH_INTERVAL

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -27,9 +27,10 @@ module Proxy::RemoteExecution::Ssh
       require 'smart_proxy_remote_execution_ssh/dispatcher'
       require 'smart_proxy_remote_execution_ssh/log_filter'
       require 'smart_proxy_remote_execution_ssh/runners'
-      require 'smart_proxy_dynflow_core'
 
       Proxy::RemoteExecution::Ssh.validate!
+
+      Proxy::Dynflow::TaskLauncherRegistry.register('ssh', Proxy::Dynflow::TaskLauncher::Batch)
     end
 
     def self.simulate?

--- a/lib/smart_proxy_remote_execution_ssh/runners/fake_script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/fake_script_runner.rb
@@ -1,5 +1,5 @@
 module Proxy::RemoteExecution::Ssh::Runners
-  class FakeScriptRunner < ForemanTasksCore::Runner::Base
+  class FakeScriptRunner < ::Proxy::Dynflow::Runner::Base
     DEFAULT_REFRESH_INTERVAL = 1
 
     @data = []

--- a/lib/smart_proxy_remote_execution_ssh/runners/polling_script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/polling_script_runner.rb
@@ -24,7 +24,7 @@ module Proxy::RemoteExecution::Ssh::Runners
       @callback_host = options[:callback_host]
       @task_id = options[:uuid]
       @step_id = options[:step_id]
-      @otp = ForemanTasksCore::OtpManager.generate_otp(@task_id)
+      @otp = Proxy::Dynflow::OtpManager.generate_otp(@task_id)
     end
 
     def prepare_start
@@ -90,7 +90,7 @@ module Proxy::RemoteExecution::Ssh::Runners
 
     def close
       super
-      ForemanTasksCore::OtpManager.drop_otp(@task_id, @otp) if @otp
+      Proxy::Dynflow::OtpManager.drop_otp(@task_id, @otp) if @otp
     end
 
     def upload_control_scripts
@@ -116,7 +116,7 @@ module Proxy::RemoteExecution::Ssh::Runners
 
     # Generates updates based on the callback data from the manual mode
     def load_event_updates(event_data)
-      continuous_output = ForemanTasksCore::ContinuousOutput.new
+      continuous_output = Proxy::Dynflow::ContinuousOutput.new
       if event_data.key?('output')
         lines = Base64.decode64(event_data['output']).sub(/\A(RUNNING|DONE).*\n/, '')
         continuous_output.add_output(lines, 'stdout')

--- a/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
@@ -96,7 +96,7 @@ module Proxy::RemoteExecution::Ssh::Runners
   end
 
   # rubocop:disable Metrics/ClassLength
-  class ScriptRunner < ForemanTasksCore::Runner::Base
+  class ScriptRunner < Proxy::Dynflow::Runner::Base
     attr_reader :execution_timeout_interval
 
     EXPECTED_POWER_ACTION_MESSAGES = ['restart host', 'shutdown host'].freeze

--- a/smart_proxy_remote_execution_ssh.gemspec
+++ b/smart_proxy_remote_execution_ssh.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rack-test', '~> 0')
   gem.add_development_dependency('rubocop', '~> 0.82.0')
 
-  gem.add_runtime_dependency('foreman-tasks-core', '>= 0.3.1')
-  gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.1')
+  gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.5')
   gem.add_runtime_dependency('net-ssh')
 end


### PR DESCRIPTION
The ForemanTasksCore has been discontinued and has been moved to
smart_proxy_dynflow. We should use those classes directly and not rely
on the compatibility layer tasks_core gem.

:boom: 