### PR TITLE
Fixes #32971 - Do not enable by default

### DIFF
--- a/settings.d/remote_execution_ssh.yml.example
+++ b/settings.d/remote_execution_ssh.yml.example
@@ -1,5 +1,5 @@
 ---
-:enabled: true
+:enabled: false
 :ssh_identity_key_file: '~/.ssh/id_rsa_foreman_proxy'
 :local_working_dir: '/var/tmp'
 :remote_working_dir: '/var/tmp'


### PR DESCRIPTION
Currently the example config file contains enabled: true which means yum install is sufficient to enable it. However, you must also create a key.  All plugins are disabled by default and this follow that.

What's worse, true means both HTTP and HTTPS which can also be less secure.