### PR TITLE
Fixes #34595 - Control socket path length

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh.rb
+++ b/lib/smart_proxy_remote_execution_ssh.rb
@@ -10,6 +10,7 @@ module Proxy::RemoteExecution
         validate_mode!
         validate_ssh_settings!
         validate_mqtt_settings!
+        validate_socket_path!
       end
 
       def private_key_file
@@ -94,6 +95,13 @@ module Proxy::RemoteExecution
 
       def requires_configured_ssh?
         %i[ssh ssh-async].include?(Plugin.settings.mode) || Plugin.settings.cockpit_integration
+      end
+
+      def validate_socket_path!
+        return unless Plugin.settings.mode == :'ssh' || Plugin.settings.mode == :'ssh-async'
+
+        socket_path = File.expand_path(Plugin.settings.socket_working_dir)
+        raise "Socket path #{socket_path} is too long" if socket_path.length > Plugin::SOCKET_PATH_MAX_LENGTH
       end
 
       def job_storage

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -2,6 +2,10 @@ module Proxy::RemoteExecution::Ssh
   class Plugin < Proxy::Plugin
     SSH_LOG_LEVELS = %w[debug info error fatal].freeze
     MODES = %i[ssh async-ssh pull pull-mqtt].freeze
+    # Unix domain socket path length is limited to 104 (on some platforms) characters
+    # Socket path is composed of custom path (max 49 characters) + job id (37 characters)
+    # + offset(17 characters) + null terminator
+    SOCKET_PATH_MAX_LENGTH = 49
 
     http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
@@ -11,6 +15,7 @@ module Proxy::RemoteExecution::Ssh
                      :ssh_user                => 'root',
                      :remote_working_dir      => '/var/tmp',
                      :local_working_dir       => '/var/tmp',
+                     :socket_working_dir      => '/var/tmp',
                      :kerberos_auth           => false,
                      :cockpit_integration     => true,
                      # When set to nil, makes REX use the runner's default interval

--- a/settings.d/remote_execution_ssh.yml.example
+++ b/settings.d/remote_execution_ssh.yml.example
@@ -3,6 +3,7 @@
 :ssh_identity_key_file: '~/.ssh/id_rsa_foreman_proxy'
 :local_working_dir: '/var/tmp'
 :remote_working_dir: '/var/tmp'
+:socket_working_dir: '/var/tmp'
 # :kerberos_auth: false
 
 # :cockpit_integration: true


### PR DESCRIPTION
Socket path length is limited to 108 (or 104, on some platforms) characters, so we can't just use local working directory for that