### PR TITLE
Fixes #34667 - Add SSL support when connecting to mqtt broker

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh.rb
+++ b/lib/smart_proxy_remote_execution_ssh.rb
@@ -60,6 +60,10 @@ module Proxy::RemoteExecution
 
         raise 'mqtt_broker has to be set when pull-mqtt mode is used' if Plugin.settings.mqtt_broker.nil?
         raise 'mqtt_port has to be set when pull-mqtt mode is used' if Plugin.settings.mqtt_port.nil?
+
+        if Plugin.settings.mqtt_tls.nil?
+          Plugin.settings.mqtt_tls = [:ssl_certificate, :ssl_private_key, :ssl_ca_file].all? { |key| ::Proxy::SETTINGS[key] }
+        end
       end
 
       def validate_ssh_log_level!

--- a/lib/smart_proxy_remote_execution_ssh.rb
+++ b/lib/smart_proxy_remote_execution_ssh.rb
@@ -62,7 +62,7 @@ module Proxy::RemoteExecution
         raise 'mqtt_port has to be set when pull-mqtt mode is used' if Plugin.settings.mqtt_port.nil?
 
         if Plugin.settings.mqtt_tls.nil?
-          Plugin.settings.mqtt_tls = [:ssl_certificate, :ssl_private_key, :ssl_ca_file].all? { |key| ::Proxy::SETTINGS[key] }
+          Plugin.settings.mqtt_tls = [:foreman_ssl_cert, :foreman_ssl_key, :foreman_ssl_ca].all? { |key| ::Proxy::SETTINGS[key] }
         end
       end
 

--- a/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
+++ b/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
@@ -90,9 +90,9 @@ module Proxy::RemoteExecution::Ssh::Actions
     def with_mqtt_client(&block)
       MQTT::Client.connect(settings.mqtt_broker, settings.mqtt_port,
                            :ssl => settings.mqtt_tls,
-                           :cert_file => ::Proxy::SETTINGS.ssl_certificate,
-                           :key_file => ::Proxy::SETTINGS.ssl_private_key,
-                           :ca_file => ::Proxy::SETTINGS.ssl_ca_file,
+                           :cert_file => ::Proxy::SETTINGS.foreman_ssl_cert,
+                           :key_file => ::Proxy::SETTINGS.foreman_ssl_key,
+                           :ca_file => ::Proxy::SETTINGS.foreman_ssl_ca,
                            &block)
     end
 

--- a/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
+++ b/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
@@ -82,9 +82,18 @@ module Proxy::RemoteExecution::Ssh::Actions
     end
 
     def mqtt_notify(payload)
-      MQTT::Client.connect(settings.mqtt_broker, settings.mqtt_port) do |c|
+      with_mqtt_client do |c|
         c.publish(mqtt_topic, JSON.dump(payload), false, 1)
       end
+    end
+
+    def with_mqtt_client(&block)
+      MQTT::Client.connect(settings.mqtt_broker, settings.mqtt_port,
+                           :ssl => settings.mqtt_tls,
+                           :cert_file => ::Proxy::SETTINGS.ssl_certificate,
+                           :key_file => ::Proxy::SETTINGS.ssl_private_key,
+                           :ca_file => ::Proxy::SETTINGS.ssl_ca_file,
+                           &block)
     end
 
     def host_name

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -18,6 +18,7 @@ module Proxy::RemoteExecution::Ssh
                      :cleanup_working_dirs    => true,
                      # :mqtt_broker             => nil,
                      # :mqtt_port               => nil,
+                     # :mqtt_tls                => nil,
                      :mode                    => :ssh
 
     plugin :ssh, Proxy::RemoteExecution::Ssh::VERSION

--- a/settings.d/remote_execution_ssh.yml.example
+++ b/settings.d/remote_execution_ssh.yml.example
@@ -26,6 +26,6 @@
 # :mqtt_port: 1883
 
 # Use of SSL can be forced either way by explicitly setting mqtt_tls setting. If
-# unset, SSL gets used if smart-proxy's ssl_certificate, ssl_private_key and
-# ssl_ca_file settings are set available.
+# unset, SSL gets used if smart-proxy's foreman_ssl_cert, foreman_ssl_key and
+# foreman_ssl_ca settings are set available.
 # :mqtt_tls:

--- a/settings.d/remote_execution_ssh.yml.example
+++ b/settings.d/remote_execution_ssh.yml.example
@@ -24,3 +24,8 @@
 # MQTT configuration, need to be set if mode is set to pull-mqtt
 # :mqtt_broker: localhost
 # :mqtt_port: 1883
+
+# Use of SSL can be forced either way by explicitly setting mqtt_tls setting. If
+# unset, SSL gets used if smart-proxy's ssl_certificate, ssl_private_key and
+# ssl_ca_file settings are set available.
+# :mqtt_tls:


### PR DESCRIPTION
Use of SSL can be forced either way by explicitly setting `mqtt_tls` setting. If unset, it gets used if certificate, private key and CA
certificate are available. Currently it reuses the `ssl_*` set of certs smart proxy has.