### PR TITLE
Fixes #34812 - add logging of script runner shell cmd at debug level

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
@@ -300,7 +300,9 @@ module Proxy::RemoteExecution::Ssh::Runners
       raise 'Async command already in progress' if @process_manager&.started?
 
       @user_method.reset
-      initialize_command(*get_args(command, true))
+      full_cmd = get_args(command, true)
+      @logger.debug("running command: #{full_cmd.join(' ')}")
+      initialize_command(*full_cmd)
 
       true
     end
@@ -310,7 +312,9 @@ module Proxy::RemoteExecution::Ssh::Runners
     end
 
     def run_sync(command, stdin: nil, publish: false, close_stdin: true, tty: false)
-      pm = Proxy::Dynflow::ProcessManager.new(get_args(command, tty))
+      full_cmd = get_args(command, tty)
+      @logger.debug("running command: #{full_cmd.join(' ')}")
+      pm = Proxy::Dynflow::ProcessManager.new(full_cmd)
       if publish
         pm.on_stdout { |data| publish_data(data, 'stdout', pm); '' }
         pm.on_stderr { |data| publish_data(data, 'stderr', pm); '' }


### PR DESCRIPTION
I have been manually adding debug logging into my foreman-proxy instances when there is a problem with REX.  It seems worth while for the default debug log to contain a trace of shell commands run.