### PR TITLE
Be more explicit about dealing with connections

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/command_logging.rb
+++ b/lib/smart_proxy_remote_execution_ssh/command_logging.rb
@@ -1,0 +1,22 @@
+# lib/command_logging.rb
+
+module Proxy::RemoteExecution::Ssh::Runners
+  module CommandLogging
+    def log_command(command, label: "Running")
+      command = command.join(' ')
+      label = "#{label}: " if label
+      logger.debug("#{label}#{command}")
+    end
+
+    def set_pm_debug_logging(pm, capture: false)
+      pm.on_stdout do |data|
+        data.each_line { |line| logger.debug(line.chomp) }
+        ''
+      end
+      pm.on_stderr do |data|
+        data.each_line { |line| logger.debug(line.chomp) }
+        ''
+      end
+    end
+  end
+end

--- a/lib/smart_proxy_remote_execution_ssh/multiplexed_ssh_connection.rb
+++ b/lib/smart_proxy_remote_execution_ssh/multiplexed_ssh_connection.rb
@@ -1,0 +1,185 @@
+require 'smart_proxy_remote_execution_ssh/command_logging'
+
+module Proxy::RemoteExecution::Ssh::Runners
+  class SensitiveString
+    def initialize(value, mask: '*****')
+      @value = value
+      @mask = mask
+    end
+
+    def inspect
+      '"' + to_s + '"'
+    end
+
+    def to_s
+      @mask
+    end
+
+    def to_str
+      @value
+    end
+  end
+
+  class AuthenticationMethod
+    attr_reader :name
+    def initialize(name, prompt: nil, password: nil)
+      @name = name
+      @prompt = prompt
+      @password = password
+    end
+
+    def ssh_command_prefix
+      return [] unless @password
+
+      prompt = ['-P', @prompt] if @prompt
+      [{'SSHPASS' => SensitiveString.new(@password)}, '/usr/bin/sshpass', '-e', prompt].compact
+    end
+
+    def ssh_options
+      ["-o PreferredAuthentications=#{name}"]
+    end
+  end
+
+  class MultiplexedSSHConnection
+    include CommandLogging
+
+    attr_reader :logger
+    def initialize(options, logger:)
+      @logger = logger
+
+      @id = options.fetch(:id)
+      @host = options.fetch(:hostname)
+      @script = options.fetch(:script)
+      @ssh_user = options.fetch(:ssh_user, 'root')
+      @ssh_port = options.fetch(:ssh_port, 22)
+      @ssh_password = options.fetch(:secrets, {}).fetch(:ssh_password, nil)
+      @key_passphrase = options.fetch(:secrets, {}).fetch(:key_passphrase, nil)
+      @host_public_key = options.fetch(:host_public_key, nil)
+      @verify_host = options.fetch(:verify_host, nil)
+      @client_private_key_file = settings.ssh_identity_key_file
+
+      @local_working_dir = options.fetch(:local_working_dir, settings.local_working_dir)
+      @socket_working_dir = options.fetch(:socket_working_dir, settings.socket_working_dir)
+      @socket = nil
+    end
+
+    def establish!
+      base = establish_ssh_options()
+
+      auth_methods = available_authentication_methods
+      auth_methods.each do |method|
+        # running "ssh -f -N" instead of "ssh true" would be cleaner, but ssh
+        # does not close its stderr which trips up the process manager which
+        # expects all FDs to be closed
+        full_command = [method.ssh_command_prefix, '/usr/bin/ssh', base, method.ssh_options, @host, 'true'].flatten
+        log_command(full_command)
+        pm = Proxy::Dynflow::ProcessManager.new(full_command)
+        pm.start!
+        if pm.status
+          raise pm.stderr.to_s
+        else
+          set_pm_debug_logging(pm)
+          pm.stdin.io.close
+          pm.run!
+        end
+        if pm.status.zero?
+          logger.debug("Established connection using authentication method #{method.name}")
+          @socket = socket_file
+          return
+        else
+          logger.debug("Failed to establish connection using authentication method #{method.name}")
+        end
+      end
+      raise "Could not establish connection to remote host using any available authentication method, tried #{auth_methods.map(&:name).join(', ')}"
+    end
+
+    def disconnect!
+      return unless connected?
+
+      cmd = command(%w[-O exit])
+      log_command(cmd, label: "Closing shared connection")
+      pm = Proxy::Dynflow::ProcessManager.new(cmd)
+      set_pm_debug_logging(pm)
+      pm.run!
+      @socket = nil
+    end
+
+    def connected?
+      !@socket.nil?
+    end
+
+    def command(cmd)
+      raise "Cannot build command to run over multiplexed connection without having an established connection" unless connected?
+
+      ['/usr/bin/ssh', reuse_ssh_options, cmd].flatten
+    end
+
+    private
+
+    def settings
+      Proxy::RemoteExecution::Ssh::Plugin.settings
+    end
+
+    def available_authentication_methods
+      methods = []
+      methods << AuthenticationMethod.new('password', password: @ssh_password) if @ssh_password
+      if verify_key_passphrase
+        methods << AuthenticationMethod.new('publickey', password: @key_passphrase, prompt: 'passphrase')
+      end
+      methods << AuthenticationMethod.new('gssapi-with-mic') if settings[:kerberos_auth]
+      raise "There are no available authentication methods" if methods.empty?
+      methods
+    end
+
+    def establish_ssh_options
+      ssh_options = []
+      ssh_options << "-o User=#{@ssh_user}"
+      ssh_options << "-o Port=#{@ssh_port}" if @ssh_port
+      ssh_options << "-o IdentityFile=#{@client_private_key_file}" if @client_private_key_file
+      ssh_options << "-o IdentitiesOnly=yes"
+      ssh_options << "-o StrictHostKeyChecking=no"
+      ssh_options << "-o UserKnownHostsFile=#{prepare_known_hosts}" if @host_public_key
+      ssh_options << "-o NumberOfPasswordPrompts=1"
+      ssh_options << "-o LogLevel=#{ssh_log_level(true)}"
+      ssh_options << "-o ControlMaster=auto"
+      ssh_options << "-o ControlPath=#{socket_file}"
+      ssh_options << "-o ControlPersist=yes"
+    end
+
+    def reuse_ssh_options
+      ["-o", "ControlPath=#{@socket}", "-o", "LogLevel=#{ssh_log_level(false)}", @host]
+    end
+
+    def socket_file
+      File.join(@socket_working_dir, @id)
+    end
+
+    def verify_key_passphrase
+      command = ['/usr/bin/ssh-keygen', '-y', '-f', File.expand_path(@client_private_key_file)]
+      log_command(command, label: "Checking if private key has passphrase")
+      pm = Proxy::Dynflow::ProcessManager.new(command)
+      pm.start!
+
+      raise pm.stderr.to_s if pm.status
+
+      pm.stdin.io.close
+      pm.run!
+
+      if pm.status.zero?
+        logger.debug("Private key is not protected with a passphrase")
+        @key_passphrase = nil
+      else
+        logger.debug("Private key is protected with a passphrase")
+      end
+
+      return true if pm.status.zero? || @key_passphrase
+
+      logger.debug("Private key is protected with a passphrase, but no passphrase was provided")
+      false
+    end
+
+    def ssh_log_level(new_connection)
+      new_connection ? settings[:ssh_log_level] : 'quiet'
+    end
+  end
+end

--- a/lib/smart_proxy_remote_execution_ssh/multiplexed_ssh_connection.rb
+++ b/lib/smart_proxy_remote_execution_ssh/multiplexed_ssh_connection.rb
@@ -36,7 +36,8 @@ module Proxy::RemoteExecution::Ssh::Runners
     end
 
     def ssh_options
-      ["-o PreferredAuthentications=#{name}"]
+      ["-o PreferredAuthentications=#{name}",
+       "-o NumberOfPasswordPrompts=#{@password ? 1 : 0}"]
     end
   end
 
@@ -139,7 +140,6 @@ module Proxy::RemoteExecution::Ssh::Runners
       ssh_options << "-o IdentitiesOnly=yes"
       ssh_options << "-o StrictHostKeyChecking=no"
       ssh_options << "-o UserKnownHostsFile=#{prepare_known_hosts}" if @host_public_key
-      ssh_options << "-o NumberOfPasswordPrompts=1"
       ssh_options << "-o LogLevel=#{ssh_log_level(true)}"
       ssh_options << "-o ControlMaster=auto"
       ssh_options << "-o ControlPath=#{socket_file}"

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -1,7 +1,7 @@
 module Proxy::RemoteExecution::Ssh
   class Plugin < Proxy::Plugin
     SSH_LOG_LEVELS = %w[debug info error fatal].freeze
-    MODES = %i[ssh async-ssh pull pull-mqtt].freeze
+    MODES = %i[ssh ssh-async pull pull-mqtt].freeze
     # Unix domain socket path length is limited to 104 (on some platforms) characters
     # Socket path is composed of custom path (max 49 characters) + job id (37 characters)
     # + offset(17 characters) + null terminator

--- a/lib/smart_proxy_remote_execution_ssh/runners/polling_script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/polling_script_runner.rb
@@ -50,13 +50,13 @@ module Proxy::RemoteExecution::Ssh::Runners
     end
 
     def refresh
+      @connection.establish! unless @connection.connected?
       begin
         pm = run_sync("#{@user_method.cli_command_prefix} #{@retrieval_script}")
+        process_retrieved_data(pm.stdout.to_s.chomp, pm.stderr.to_s.chomp)
       rescue StandardError => e
         @logger.info("Error while connecting to the remote host on refresh: #{e.message}")
       end
-
-      process_retrieved_data(pm.stdout.to_s.chomp, pm.stderr.to_s.chomp)
     ensure
       destroy_session
     end
@@ -139,7 +139,7 @@ module Proxy::RemoteExecution::Ssh::Runners
     end
 
     def destroy_session
-      if @session
+      if @connection.connected?
         @logger.debug("Closing session with #{@ssh_user}@#{@host}")
         close_session
       end

--- a/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
@@ -116,7 +116,7 @@ module Proxy::RemoteExecution::Ssh::Runners
       @cleanup_working_dirs = options.fetch(:cleanup_working_dirs, settings.cleanup_working_dirs)
       @first_execution = options.fetch(:first_execution, false)
       @user_method = user_method
-      @connection = MultiplexedSSHConnection.new(options.merge(:id => @id), logger: logger)
+      @options = options
     end
 
     def self.build(options, suspended_action:)
@@ -145,6 +145,7 @@ module Proxy::RemoteExecution::Ssh::Runners
     def start
       Proxy::RemoteExecution::Utils.prune_known_hosts!(@host, @ssh_port, logger) if @first_execution
       ensure_local_directory(@socket_working_dir)
+      @connection = MultiplexedSSHConnection.new(@options.merge(:id => @id), logger: logger)
       @connection.establish!
       preflight_checks
       prepare_start

--- a/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'smart_proxy_dynflow/runner/process_manager_command'
 require 'smart_proxy_dynflow/process_manager'
+require 'smart_proxy_remote_execution_ssh/multiplexed_ssh_connection'
 
 module Proxy::RemoteExecution::Ssh::Runners
   class EffectiveUserMethod
@@ -92,6 +93,8 @@ module Proxy::RemoteExecution::Ssh::Runners
   # rubocop:disable Metrics/ClassLength
   class ScriptRunner < Proxy::Dynflow::Runner::Base
     include Proxy::Dynflow::Runner::ProcessManagerCommand
+    include CommandLogging
+
     attr_reader :execution_timeout_interval
 
     EXPECTED_POWER_ACTION_MESSAGES = ['restart host', 'shutdown host'].freeze
@@ -103,10 +106,7 @@ module Proxy::RemoteExecution::Ssh::Runners
       @script = options.fetch(:script)
       @ssh_user = options.fetch(:ssh_user, 'root')
       @ssh_port = options.fetch(:ssh_port, 22)
-      @ssh_password = options.fetch(:secrets, {}).fetch(:ssh_password, nil)
-      @key_passphrase = options.fetch(:secrets, {}).fetch(:key_passphrase, nil)
       @host_public_key = options.fetch(:host_public_key, nil)
-      @verify_host = options.fetch(:verify_host, nil)
       @execution_timeout_interval = options.fetch(:execution_timeout_interval, nil)
 
       @client_private_key_file = settings.ssh_identity_key_file
@@ -116,6 +116,7 @@ module Proxy::RemoteExecution::Ssh::Runners
       @cleanup_working_dirs = options.fetch(:cleanup_working_dirs, settings.cleanup_working_dirs)
       @first_execution = options.fetch(:first_execution, false)
       @user_method = user_method
+      @connection = MultiplexedSSHConnection.new(options.merge(:id => @id), logger: logger)
     end
 
     def self.build(options, suspended_action:)
@@ -143,7 +144,8 @@ module Proxy::RemoteExecution::Ssh::Runners
 
     def start
       Proxy::RemoteExecution::Utils.prune_known_hosts!(@host, @ssh_port, logger) if @first_execution
-      establish_connection
+      ensure_local_directory(@socket_working_dir)
+      @connection.establish!
       preflight_checks
       prepare_start
       script = initialization_script
@@ -170,16 +172,6 @@ module Proxy::RemoteExecution::Ssh::Runners
                               user_method: @user_method,
                               close_stdin: false)
       end
-    end
-
-    def establish_connection
-      # run_sync ['-f', '-N'] would be cleaner, but ssh does not close its
-      # stderr which trips up the process manager which expects all FDs to be
-      # closed
-      ensure_remote_command(
-        'true',
-        error: 'Failed to establish connection to remote host, exit code: %{exit_code}'
-      )
     end
 
     def prepare_start
@@ -232,11 +224,7 @@ module Proxy::RemoteExecution::Ssh::Runners
     def close_session
       raise 'Control socket file does not exist' unless File.exist?(socket_file)
       @logger.debug("Sending exit request for session #{@ssh_user}@#{@host}")
-      args = ['/usr/bin/ssh', @host, "-o", "ControlPath=#{socket_file}", "-O", "exit"].flatten
-      pm = Proxy::Dynflow::ProcessManager.new(args)
-      pm.on_stdout { |data| @logger.debug "[close_session]: #{data.chomp}"; data }
-      pm.on_stderr { |data| @logger.debug "[close_session]: #{data.chomp}"; data }
-      pm.run!
+      @connection.disconnect!
     end
 
     def close
@@ -264,32 +252,8 @@ module Proxy::RemoteExecution::Ssh::Runners
       @process_manager && @cleanup_working_dirs
     end
 
-    def ssh_options(with_pty = false, quiet: false)
-      ssh_options = []
-      ssh_options << "-tt" if with_pty
-      ssh_options << "-o User=#{@ssh_user}"
-      ssh_options << "-o Port=#{@ssh_port}" if @ssh_port
-      ssh_options << "-o IdentityFile=#{@client_private_key_file}" if @client_private_key_file
-      ssh_options << "-o IdentitiesOnly=yes"
-      ssh_options << "-o StrictHostKeyChecking=no"
-      ssh_options << "-o PreferredAuthentications=#{available_authentication_methods.join(',')}"
-      ssh_options << "-o UserKnownHostsFile=#{prepare_known_hosts}" if @host_public_key
-      ssh_options << "-o NumberOfPasswordPrompts=1"
-      ssh_options << "-o LogLevel=#{quiet ? 'quiet' : settings[:ssh_log_level]}"
-      ssh_options << "-o ControlMaster=auto"
-      ssh_options << "-o ControlPath=#{socket_file}"
-      ssh_options << "-o ControlPersist=yes"
-    end
-
     def settings
       Proxy::RemoteExecution::Ssh::Plugin.settings
-    end
-
-    def get_args(command, with_pty = false, quiet: false)
-      args = []
-      args = [{'SSHPASS' => @key_passphrase}, '/usr/bin/sshpass', '-P', 'passphrase', '-e'] if @key_passphrase
-      args = [{'SSHPASS' => @ssh_password}, '/usr/bin/sshpass', '-e'] if @ssh_password
-      args += ['/usr/bin/ssh', @host, ssh_options(with_pty, quiet: quiet), command].flatten
     end
 
     # Initiates run of the remote command and yields the data when
@@ -299,7 +263,9 @@ module Proxy::RemoteExecution::Ssh::Runners
       raise 'Async command already in progress' if @process_manager&.started?
 
       @user_method.reset
-      initialize_command(*get_args(command, true, quiet: true))
+      cmd = @connection.command([tty_flag(true), command].flatten.compact)
+      log_command(cmd)
+      initialize_command(*cmd)
 
       true
     end
@@ -308,17 +274,15 @@ module Proxy::RemoteExecution::Ssh::Runners
       @process_manager&.started? && @user_method.sent_all_data?
     end
 
-    def run_sync(command, stdin: nil, close_stdin: true, tty: false, user_method: nil)
-      pm = Proxy::Dynflow::ProcessManager.new(get_args(command, tty))
-      callback = proc do |data|
-        data.each_line do |line|
-          logger.debug(line.chomp) if user_method.nil? || !user_method.filter_password?(line)
-          user_method.on_data(data, pm.stdin) if user_method
-        end
-        ''
-      end
-      pm.on_stdout(&callback)
-      pm.on_stderr(&callback)
+    def tty_flag(tty)
+      '-tt' if tty
+    end
+
+    def run_sync(command, stdin: nil, close_stdin: true, tty: false)
+      cmd = @connection.command([tty_flag(tty), command].flatten.compact)
+      log_command(cmd)
+      pm = Proxy::Dynflow::ProcessManager.new(cmd)
+      set_pm_debug_logging(pm)
       pm.start!
       unless pm.status
         pm.stdin.io.puts(stdin) if stdin
@@ -427,13 +391,6 @@ module Proxy::RemoteExecution::Ssh::Runners
       if EXPECTED_POWER_ACTION_MESSAGES.any? { |message| last_output['output'] =~ /^#{message}/ }
         @expecting_disconnect = true
       end
-    end
-
-    def available_authentication_methods
-      methods = %w[publickey] # Always use pubkey auth as fallback
-      methods << 'gssapi-with-mic' if settings[:kerberos_auth]
-      methods.unshift('password') if @ssh_password
-      methods
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
@@ -278,11 +278,11 @@ module Proxy::RemoteExecution::Ssh::Runners
       '-tt' if tty
     end
 
-    def run_sync(command, stdin: nil, close_stdin: true, tty: false)
+    def run_sync(command, stdin: nil, close_stdin: true, tty: false, user_method: false)
       cmd = @connection.command([tty_flag(tty), command].flatten.compact)
       log_command(cmd)
       pm = Proxy::Dynflow::ProcessManager.new(cmd)
-      set_pm_debug_logging(pm)
+      set_pm_debug_logging(pm, user_method: user_method)
       pm.start!
       unless pm.status
         pm.stdin.io.puts(stdin) if stdin

--- a/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
@@ -278,7 +278,7 @@ module Proxy::RemoteExecution::Ssh::Runners
       '-tt' if tty
     end
 
-    def run_sync(command, stdin: nil, close_stdin: true, tty: false, user_method: false)
+    def run_sync(command, stdin: nil, close_stdin: true, tty: false, user_method: nil)
       cmd = @connection.command([tty_flag(tty), command].flatten.compact)
       log_command(cmd)
       pm = Proxy::Dynflow::ProcessManager.new(cmd)


### PR DESCRIPTION
This allows us to:
- try using both password and key passphrase
- have clearer idea what's going on
- have better logging
- decouple connection handling logic from what we want to run on the remote end