### PR TITLE
Rate limit

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
+++ b/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
@@ -106,6 +106,8 @@ module Proxy::RemoteExecution::Ssh::Actions
     end
 
     def mqtt_start(otp_password)
+      return unless rate_limit_allowed?
+
       payload = mqtt_payload_base.merge(
         content: "#{input[:proxy_url]}/ssh/jobs/#{input[:job_uuid]}",
         metadata: {
@@ -164,6 +166,11 @@ module Proxy::RemoteExecution::Ssh::Actions
 
     def job_storage
       Proxy::RemoteExecution::Ssh.job_storage
+    end
+
+    def rate_limit_allowed?
+      limit = settings[:pull_rate_limit]
+      limit.nil? || limit > job_storage.running_job_count
     end
 
     def mqtt_payload_base

--- a/lib/smart_proxy_remote_execution_ssh/job_storage.rb
+++ b/lib/smart_proxy_remote_execution_ssh/job_storage.rb
@@ -12,6 +12,7 @@ module Proxy::RemoteExecution::Ssh
         String :execution_plan_uuid, fixed: true, size: 36, null: false, index: true
         Integer :run_step_id, null: false
         String :job, text: true
+        Boolean :running, default: false
       end
     end
 
@@ -36,6 +37,14 @@ module Proxy::RemoteExecution::Ssh
 
     def drop_job(execution_plan_uuid, run_step_id)
       jobs.where(execution_plan_uuid: execution_plan_uuid, run_step_id: run_step_id).delete
+    end
+
+    def mark_as_running(uuid)
+      jobs.where(uuid: uuid).update(running: true)
+    end
+
+    def running_job_count
+      jobs.where(running: true).count
     end
 
     private

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -25,6 +25,7 @@ module Proxy::RemoteExecution::Ssh
                      # :mqtt_broker             => nil,
                      # :mqtt_port               => nil,
                      # :mqtt_tls                => nil,
+                     # :pull_rate_limit         => nil,
                      :mode                    => :ssh,
                      :mqtt_resend_interval    => 900
 

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -25,7 +25,8 @@ module Proxy::RemoteExecution::Ssh
                      # :mqtt_broker             => nil,
                      # :mqtt_port               => nil,
                      # :mqtt_tls                => nil,
-                     :mode                    => :ssh
+                     :mode                    => :ssh,
+                     :mqtt_resend_interval    => 900
 
     capability(proc { 'cockpit' if settings.cockpit_integration })
 

--- a/settings.d/remote_execution_ssh.yml.example
+++ b/settings.d/remote_execution_ssh.yml.example
@@ -36,3 +36,7 @@
 # The notification is sent over mqtt every $mqtt_resend_interval seconds, until
 # the job is picked up by the host or cancelled
 # :mqtt_resend_interval: 900
+
+# Limit the number of jobs the proxy is allowed to run concurrently when using
+# one of the pull modes
+# :pull_rate_limit:

--- a/settings.d/remote_execution_ssh.yml.example
+++ b/settings.d/remote_execution_ssh.yml.example
@@ -32,3 +32,7 @@
 # unset, SSL gets used if smart-proxy's foreman_ssl_cert, foreman_ssl_key and
 # foreman_ssl_ca settings are set available.
 # :mqtt_tls:
+
+# The notification is sent over mqtt every $mqtt_resend_interval seconds, until
+# the job is picked up by the host or cancelled
+# :mqtt_resend_interval: 900

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -165,7 +165,7 @@ module Proxy::RemoteExecution::Ssh
           auth = Proxy::Dynflow::OtpManager.tokenize(execution_plan_uuid, pass)
 
           fake_world = mock
-          fake_world.expects(:event).with(execution_plan_uuid, run_step_id, Actions::PullScript::JobDelivered)
+          fake_world.expects(:event).with { |uuid, step_id, event| uuid == execution_plan_uuid && step_id == run_step_id && event.is_a?(Actions::PullScript::JobDelivered) }
           Proxy::RemoteExecution::Ssh::Api.any_instance.expects(:world).returns(fake_world)
 
           get "/jobs/#{uuid}", {}, 'HTTP_AUTHORIZATION' => "Basic #{auth}"
@@ -178,7 +178,7 @@ module Proxy::RemoteExecution::Ssh
         it 'returns content if there is some and notifies the action' do
           Proxy::RemoteExecution::Ssh::Api.any_instance.expects(:https_cert_cn).returns(hostname)
           fake_world = mock
-          fake_world.expects(:event).with(execution_plan_uuid, run_step_id, Actions::PullScript::JobDelivered)
+          fake_world.expects(:event).with { |uuid, step_id, event| uuid == execution_plan_uuid && step_id == run_step_id && event.is_a?(Actions::PullScript::JobDelivered) }
           Proxy::RemoteExecution::Ssh::Api.any_instance.expects(:world).returns(fake_world)
 
           get "/jobs/#{uuid}"


### PR DESCRIPTION
Job storage now has an additional column indicating whether the job is
running on a client. If a limit is set and reached and a client requests
another job, it will get 429 - Too many requests.

It would be cleaner to set some HTTP headers, but as far as I know
yggdrasil does not care about them.

Includes:
- https://github.com/theforeman/smart_proxy_remote_execution_ssh/pull/87