### PR TITLE
Fixes #35542 - Fix async ssh

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/runners/polling_script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/polling_script_runner.rb
@@ -133,7 +133,6 @@ module Proxy::RemoteExecution::Ssh::Runners
     def cleanup
       if @cleanup_working_dirs
         ensure_remote_command("rm -rf #{remote_command_dir}",
-                              publish: true,
                               error: "Unable to remove working directory #{remote_command_dir} on remote system, exit code: %{exit_code}")
       end
     end

--- a/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
@@ -316,7 +316,7 @@ module Proxy::RemoteExecution::Ssh::Runners
           logger.debug(line.chomp) if user_method.nil? || !user_method.filter_password?(line)
           user_method.on_data(data, pm.stdin) if user_method
         end
-        ''
+        data
       end
       pm.on_stdout(&callback)
       pm.on_stderr(&callback)


### PR DESCRIPTION
> lib/.../script_runner.rb

Without this change, the job would hang around forever, as the output of the command we run to check the job on the remote end would be discarded.

> lib/.../polling_script_runner.rb

This kwarg does not exist anymore.