### PR TITLE
Fixes #35620 - Limit the maximum number of connections to MQTT broker

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
+++ b/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
@@ -129,18 +129,9 @@ module Proxy::RemoteExecution::Ssh::Actions
     end
 
     def mqtt_notify(payload)
-      with_mqtt_client do |c|
+      ::Proxy::RemoteExecution::Ssh::MQTT.with_pooled_connection do |c|
         c.publish(mqtt_topic, JSON.dump(payload), false, 1)
       end
-    end
-
-    def with_mqtt_client(&block)
-      MQTT::Client.connect(settings.mqtt_broker, settings.mqtt_port,
-                           :ssl => settings.mqtt_tls,
-                           :cert_file => ::Proxy::SETTINGS.foreman_ssl_cert || ::Proxy::SETTINGS.ssl_certificate,
-                           :key_file => ::Proxy::SETTINGS.foreman_ssl_key || ::Proxy::SETTINGS.ssl_private_key,
-                           :ca_file => ::Proxy::SETTINGS.foreman_ssl_ca || ::Proxy::SETTINGS.ssl_ca_file,
-                           &block)
     end
 
     def host_name

--- a/lib/smart_proxy_remote_execution_ssh/mqtt.rb
+++ b/lib/smart_proxy_remote_execution_ssh/mqtt.rb
@@ -1,0 +1,36 @@
+require 'connection_pool'
+require 'mqtt'
+
+module Proxy::RemoteExecution::Ssh
+  class MQTT
+    class << self
+      def connection_pool
+        @mqtt_connection_pool ||= ::ConnectionPool.new(size: 5) { self.new }
+      end
+
+      def with_pooled_connection(&block)
+        connection_pool.with do |client|
+          client.with_connection(&block)
+        end
+      end
+    end
+
+    def initialize
+      @client = ::MQTT::Client.new
+      @client.host = ::Proxy::RemoteExecution::Ssh::Plugin.settings.mqtt_broker
+      @client.port = ::Proxy::RemoteExecution::Ssh::Plugin.settings.mqtt_port
+      @client.ssl = ::Proxy::RemoteExecution::Ssh::Plugin.settings.mqtt_tls
+      @client.cert_file = ::Proxy::SETTINGS.foreman_ssl_cert || ::Proxy::SETTINGS.ssl_certificate
+      @client.key_file = ::Proxy::SETTINGS.foreman_ssl_key || ::Proxy::SETTINGS.ssl_private_key
+      @client.ca_file = ::Proxy::SETTINGS.foreman_ssl_ca || ::Proxy::SETTINGS.ssl_ca_file
+    end
+
+    def with_connection(&block)
+      @client.connect(&block)
+    end
+
+    def close
+      @client.disconnect if @client.connected?
+    end
+  end
+end

--- a/lib/smart_proxy_remote_execution_ssh/plugin.rb
+++ b/lib/smart_proxy_remote_execution_ssh/plugin.rb
@@ -45,6 +45,10 @@ module Proxy::RemoteExecution::Ssh
       Proxy::RemoteExecution::Ssh.validate!
 
       Proxy::Dynflow::TaskLauncherRegistry.register('ssh', Proxy::Dynflow::TaskLauncher::Batch)
+
+      if settings.mode == :'pull-mqtt'
+        require 'smart_proxy_remote_execution_ssh/mqtt'
+      end
     end
 
     def self.simulate?


### PR DESCRIPTION
Note, the pool pools clients, not active connections. Consumer of the pool are expected to borrow a client, establish a connection, do what they need, close the connection and return the client.

I also have a [variant with persistent connections](https://github.com/theforeman/smart_proxy_remote_execution_ssh/compare/master...adamruzicka:smart_proxy_remote_execution_ssh:persistent?expand=1), but ruby-mqtt has some quirks and [the workaround](https://github.com/theforeman/smart_proxy_remote_execution_ssh/compare/master...adamruzicka:smart_proxy_remote_execution_ssh:persistent?expand=1#diff-633607f9ce7a38c13632bb2746b36c64cf6014ddc4b336d027d225b02fc8389cR42-R63) in there makes me worried a bit