### PR TITLE
Fixes #35905 - Fix time to pickup

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/api.rb
+++ b/lib/smart_proxy_remote_execution_ssh/api.rb
@@ -71,6 +71,14 @@ module Proxy::RemoteExecution
         end
       end
 
+      get "/jobs/:job_uuid/cancel" do |job_uuid|
+        do_authorize_with_ssl_client
+
+        with_authorized_job(job_uuid) do |job_record|
+          {}
+        end
+      end
+
       private
 
       def notify_job(job_record, event)


### PR DESCRIPTION
TODOs:
- [x] ygg up, time to pickup shorter than job, job should be successful
- [x] ygg down, job should fail due to time to pickup
- [x] ygg up, timeout to kill shorter than job, job should fail
- [x] ygg down, timeout to kill shorter than time to pickup, job should fail
- [x] ygg up, no timeouts, manual cancel
- [x] ygg down, no timeouts, manual cancel