### PR TITLE
Fixes #36655 - Fail the job if exit code is not written

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
@@ -194,7 +194,11 @@ module Proxy::RemoteExecution::Ssh::Runners
         #{@remote_script_wrapper} #{@user_method.cli_command_prefix}#{su_method ? "'#{@remote_script} < /dev/null '" : "#{@remote_script} < /dev/null"}
         echo \\$?>#{@exit_code_path}
         EOF
-        exit $(cat #{@exit_code_path})
+        if [ -f #{@exit_code_path} ] && [ $(wc -l < #{@exit_code_path}) -gt 0 ]; then
+          exit $(cat #{@exit_code_path})
+        else
+          exit 1
+        fi
       SCRIPT
     end
 


### PR DESCRIPTION
In case the disk gets full, the exit code file might not be there at all or might be empty.