### PR TITLE
Fixes #37475 - Avoid kwargs in action methods

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
+++ b/lib/smart_proxy_remote_execution_ssh/actions/pull_script.rb
@@ -20,9 +20,9 @@ module Proxy::RemoteExecution::Ssh::Actions
 
     execution_plan_hooks.use :cleanup, :on => :stopped
 
-    def plan(action_input, mqtt: false)
+    def plan(action_input)
       super(action_input)
-      input[:with_mqtt] = mqtt
+      input[:with_mqtt] = Proxy::RemoteExecution::Ssh::Plugin.settings.mode == :'pull-mqtt'
     end
 
     def run(event = nil)

--- a/lib/smart_proxy_remote_execution_ssh/actions/run_script.rb
+++ b/lib/smart_proxy_remote_execution_ssh/actions/run_script.rb
@@ -10,8 +10,7 @@ module Proxy::RemoteExecution::Ssh
         when :ssh, :'ssh-async'
           plan_action(ScriptRunner, *args)
         when :pull, :'pull-mqtt'
-          plan_action(PullScript, *args,
-                      mqtt: mode == :'pull-mqtt')
+          plan_action(PullScript, *args)
         end
       end
     end


### PR DESCRIPTION
It used to work on Ruby 2, but broke with Ruby 3.