### PR TITLE
Refs #37570 - use correct POSIX shell syntax for the wrapper script

### DIFF
--- a/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
+++ b/lib/smart_proxy_remote_execution_ssh/runners/script_runner.rb
@@ -185,7 +185,7 @@ module Proxy::RemoteExecution::Ssh::Runners
       @pid_path = File.join(File.dirname(@remote_script), 'pid')
       su_method = @user_method.instance_of?(SuUserMethod)
       wrapper = <<~SCRIPT
-        if [ "$1" == "inner" ]; then
+        if [ "$1" = "inner" ]; then
           echo \$$ > #{@pid_path}
           (
             #{@user_method.cli_command_prefix}#{su_method ? "'exec #{@remote_script} < /dev/null '" : "#{@remote_script} < /dev/null"}


### PR DESCRIPTION
Comparison with `==` is a bashism, POSIX [/test wants a single `=`.
The code worked on EL as there /bin/sh is bash, but Debian and friends
have dash which is POSIX but does not support `[ "a" == "b" ]`.
